### PR TITLE
Fix the build on GCC 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,10 @@ CXXFLAGS = --std=c++17
 
 CC = $(CXX)
 CCFLAGS = $(CXXFLAGS)
+LDFLAGS = -lstdc++fs
 
 flopgen: fatfs/diskio.o fatfs/fattime.o fatfs/ff.o fatfs/ffsystem.o fatfs/ffunicode.o classes.o image.o filediskio.o main.o
-	$(CXX) -o $@ $^
+	$(CXX) -o $@ $^ $(LDFLAGS)
 
 fatfs/%.o: fatfs/%.c fatfs/%.h
 classes.o: classes.cpp classes.hpp image.hpp


### PR DESCRIPTION
GCC 8 requires `-lstdc++fs` to use `std::filesystem`, so add it to `LDFLAGS`.

Full build failure:
```
g++ -o flopgen fatfs/diskio.o fatfs/fattime.o fatfs/ff.o fatfs/ffsystem.o fatfs/ffunicode.o classes.o image.o filediskio.o main.o
/usr/bin/ld: classes.o: in function `File::get_size()':
classes.cpp:(.text+0x582): undefined reference to `std::filesystem::file_size(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: classes.o: in function `Directory::Directory(std::filesystem::__cxx11::path)':
classes.cpp:(.text+0x6f1): undefined reference to `std::filesystem::__cxx11::directory_iterator::operator*() const'
/usr/bin/ld: classes.cpp:(.text+0x8e5): undefined reference to `std::filesystem::__cxx11::directory_iterator::operator++()'
/usr/bin/ld: classes.o: in function `std::filesystem::__cxx11::directory_entry::status() const':
classes.cpp:(.text._ZNKSt10filesystem7__cxx1115directory_entry6statusEv[_ZNKSt10filesystem7__cxx1115directory_entry6statusEv]+0x14): undefined reference to `std::filesystem::status(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: classes.o: in function `std::filesystem::__cxx11::directory_iterator::directory_iterator(std::filesystem::__cxx11::path const&)':
classes.cpp:(.text._ZNSt10filesystem7__cxx1118directory_iteratorC2ERKNS0_4pathE[_ZNSt10filesystem7__cxx1118directory_iteratorC5ERKNS0_4pathE]+0x26): undefined reference to `std::filesystem::__cxx11::directory_iterator::directory_iterator(std::filesystem::__cxx11::path const&, std::filesystem::directory_options, std::error_code*)'
/usr/bin/ld: classes.o: in function `std::filesystem::exists(std::filesystem::__cxx11::path const&)':
classes.cpp:(.text._ZNSt10filesystem6existsERKNS_7__cxx114pathE[_ZNSt10filesystem6existsERKNS_7__cxx114pathE]+0x14): undefined reference to `std::filesystem::status(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: classes.o: in function `std::filesystem::is_directory(std::filesystem::__cxx11::path const&)':
classes.cpp:(.text._ZNSt10filesystem12is_directoryERKNS_7__cxx114pathE[_ZNSt10filesystem12is_directoryERKNS_7__cxx114pathE]+0x14): undefined reference to `std::filesystem::status(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: classes.o: in function `std::filesystem::is_regular_file(std::filesystem::__cxx11::path const&)':
classes.cpp:(.text._ZNSt10filesystem15is_regular_fileERKNS_7__cxx114pathE[_ZNSt10filesystem15is_regular_fileERKNS_7__cxx114pathE]+0x14): undefined reference to `std::filesystem::status(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: classes.o: in function `std::filesystem::__cxx11::path::path<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::filesystem::__cxx11::path>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::filesystem::__cxx11::path::format)':
classes.cpp:(.text._ZNSt10filesystem7__cxx114pathC2INSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES1_EERKT_NS1_6formatE[_ZNSt10filesystem7__cxx114pathC5INSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES1_EERKT_NS1_6formatE]+0x64): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
collect2: error: ld returned 1 exit status
make: *** [Makefile:7: flopgen] Error 1
```

GCC version used:
```
$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/8/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Debian 8.3.0-6' --with-bugurl=file:///usr/share/doc/gcc-8/README.Bugs --enable-languages=c,ada,c++,go,brig,d,fortran,objc,obj-c++ --prefix=/usr --with-gcc-major-version-only --program-suffix=-8 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-bootstrap --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --enable-default-pie --with-system-zlib --with-target-system-zlib --enable-objc-gc=auto --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 8.3.0 (Debian 8.3.0-6) 
```