### PR TITLE
Update Makefile for macOS build in 2023

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ CXXFLAGS = --std=c++17
 
 CC = $(CXX)
 CCFLAGS = $(CXXFLAGS)
-LDFLAGS = -lstdc++fs
 
 flopgen: fatfs/diskio.o fatfs/fattime.o fatfs/ff.o fatfs/ffsystem.o fatfs/ffunicode.o classes.o image.o filediskio.o main.o
 	$(CXX) -o $@ $^ $(LDFLAGS)


### PR DESCRIPTION
for building in 2023

`LDFLAGS = -lstdc++fs` is no longer required

tested on macOS
